### PR TITLE
feat: Add getEnvOrDefault function with default values for database config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,40 @@
 # go-flow-migrate
+
 An opensource Golang Migration tool for gophers! It allows you to easily manage your database schema changes, ensuring smooth migrations and rollbacks.
 
 ## 📁 Configuration
 
 To get started, you need to create a .env file to store your database credentials.
+
 - Create a .env file in your application’s root.
 - Inside your .env file set these key value pairs needed for the migrator to run
+
 ```yaml
 DB_HOST=
 DB_PORT=
 DB_USER=
 DB_PASSWORD=
 DB_NAME=
+DB_SSL_MODE=
+DB_SCHEMA=
 ```
+
 ## 🚀 Installation
 
 Add go-flow-migrate to your project using go get:
+
 ```go
 go get github.com/einnovationlabs/go-flow-migrate
 ```
+
 ## 🚦 Starting the Migrator
+
 ```go
 flow.Start()
 ```
+
 Upon starting, you’ll see the following prompt:
+
 ```
 Welcome to flow migrate.
 1. Create a migration file
@@ -34,12 +45,16 @@ Select an option to proceed:
 ```
 
 ## 🛠️ Creating a Migration File
+
 To create a new migration file, select option 1 from the prompt or directly use the Create(migration name) method:
+
 ```go
 flow.Create("create users table")
 ```
+
 This command will create a migration file containing up and down sections for you to define your migration scripts.
 Example Migration File:
+
 ```yaml
 version: 20250108013715
 name: Create User Table
@@ -54,29 +69,34 @@ up: |
 down: |
   DROP TABLE users;
 ```
+
 - up: SQL commands to apply the migration (e.g., creating tables or columns).
 - down: SQL commands to reverse the migration (e.g., dropping tables or columns).
 
 ## 🔼 Running Migrations
 
 After defining your migration scripts, select option 2 from the prompt or directly run all pending migrations using the MigrateUp method:
+
 ```go
 flow.MigrateUp()
 ```
+
 This will execute the up scripts in all migration files that haven’t been applied yet.
 
 ## 🔽 Rolling Back Migrations
 
 To rollback migrations, select option 3 from the prompt or use the MigrateDown() method:
+
 ```go
 flow.MigrateDown(step int)
 ```
+
 - step: Number of migrations to roll back. For example,
   - step = 1 rolls back the most recent migration
   - step = 3 rolls back the last three migrations.
 
-
 ## 🛡️ Best Practices
+
 - Use descriptive names for your migration files (e.g., add users table).
 - Test migrations in a staging environment before running them in production.
 - Always keep backups of your database before applying significant changes.
@@ -90,4 +110,3 @@ For questions or issues, please reach out via GitHub Issues.
 Flow is open-source software licensed under the MIT License.
 
 Happy Migrating! 🚀
-

--- a/db_utils.go
+++ b/db_utils.go
@@ -2,10 +2,8 @@ package flow
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 	"log"
-	"os"
 	"strconv"
 
 	"github.com/joho/godotenv"
@@ -20,6 +18,7 @@ type DB struct {
 	DBName     string
 	Directory  string
 	SSLMode    string
+	Schema     string
 	Connection *sql.DB
 }
 
@@ -28,27 +27,28 @@ func ReadDatabaseConfiguration(directory string) *DB {
 	godotenv.Load()
 
 	config := DB{
-		Host:      getEnv("DB_HOST"),
-		Port:      getEnv("DB_PORT"),
-		User:      getEnv("DB_USER"),
-		Password:  getEnv("DB_PASSWORD"),
-		DBName:    getEnv("DB_NAME"),
-		SSLMode:   getEnv("DB_SSL_MODE"),
+		Host:      getEnvOrDefault("DB_HOST", ""),
+		Port:      getEnvOrDefault("DB_PORT", ""),
+		User:      getEnvOrDefault("DB_USER", ""),
+		Password:  getEnvOrDefault("DB_PASSWORD", ""),
+		DBName:    getEnvOrDefault("DB_NAME", ""),
+		SSLMode:   getEnvOrDefault("DB_SSL_MODE", "disable"),
+		Schema:    getEnvOrDefault("DB_SCHEMA", "public"),
 		Directory: directory,
 	}
 
 	return &config
 }
 
-func getEnv(key string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
-	}
+// func getEnv(key string) string {
+// 	if value := os.Getenv(key); value != "" {
+// 		return value
+// 	}
 
-	err := errors.New(key)
-	checkError(err, "Fatal: Failed to fetch credentials - %v\n")
-	return ""
-}
+// 	err := errors.New(key)
+// 	checkError(err, "Fatal: Failed to fetch credentials - %v\n")
+// 	return ""
+// }
 
 // Connect establishes and returns a PostgreSQL DB instance
 func (d *DB) Connect() {
@@ -58,8 +58,8 @@ func (d *DB) Connect() {
 	}
 
 	psqlconn := fmt.Sprintf(
-		"host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
-		d.Host, portInt, d.User, d.Password, d.DBName, d.SSLMode,
+		"host=%s port=%d user=%s password=%s dbname=%s sslmode=%s search_path=%s",
+		d.Host, portInt, d.User, d.Password, d.DBName, d.SSLMode, d.Schema,
 	)
 
 	db, err := sql.Open("postgres", psqlconn)

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,9 @@
 package flow
 
-import "log"
+import (
+	"log"
+	"os"
+)
 
 func checkError(err error, message_wrapper string) {
 	log.Fatalf(message_wrapper, err)
@@ -12,4 +15,11 @@ func logError(err error, messageWrapper string) {
 
 func logInfo(message string) {
 	log.Printf("%s", "INFO: "+message)
+}
+
+func getEnvOrDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
 }


### PR DESCRIPTION
- Added getEnvOrDefault utility function in utils.go
- Replaced strict getEnv calls with getEnvOrDefault in db_utils.go
- Set sensible defaults: SSL_MODE=disable, SCHEMA=public
- Allow empty defaults for required fields (HOST, PORT, USER, PASSWORD, NAME)
- Remove old getEnv function that would fatal on missing env vars